### PR TITLE
catch axios errors

### DIFF
--- a/lib/feeds.js
+++ b/lib/feeds.js
@@ -60,6 +60,7 @@ function fetchAndParseFeeds(url) {
       res.data.pipe(feedparser)
       
     })
+    .catch(err => reject(err) ) // axios errors
   })
 }
 


### PR DESCRIPTION
Whoops forgot to catch `axios` errors. Now we do.